### PR TITLE
RFC: Remove eval, regex capture; update for v0.4 (fixes #12, fixes #14)

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -175,11 +175,12 @@ are preceded by a comma and end with "end"::
 Regular Expressions
 -------------------
 
-Match.jl used to have regular expression handling, but it was implemented
-using ``eval``, which is generally a bad idea and caused some problems.
+Match.jl used to have complex regular expression handling, but it was
+implemented using ``eval``, which is generally a bad idea and was the
+source of some undesirable behavior.
 
-With some work, it is possible to reimplement, but it's unclear if this is
-a good idea yet.
+With some work, it is possible to reimplement, but it's unclear if
+this is a good idea yet.
 
 .. rst-class:: strike
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -175,6 +175,14 @@ are preceded by a comma and end with "end"::
 Regular Expressions
 -------------------
 
+Match.jl used to have regular expression handling, but it was implemented
+using ``eval``, which is generally a bad idea and caused some problems.
+
+With some work, it is possible to reimplement, but it's unclear if this is
+a good idea yet.
+
+.. rst-class:: strike
+
 Julia has regular expressions already, of course.  Match builds
 on them by allowing binding, by treating patterns like functions::
 
@@ -222,6 +230,8 @@ on them by allowing binding, by treating patterns like functions::
 
   julia> regex_test("Open the pod bay doors, HAL.")
   "No match"
+
+.. rst-class:: strike
 
 As noted in the comment above, matching against regular expressions in
 variables only works when the variables are global variables

--- a/src/Match.jl
+++ b/src/Match.jl
@@ -6,12 +6,6 @@ export @match, @ismatch
 
 import Base.ismatch
 
-# Julia 0.2 compatibility patch
-if isless(Base.VERSION, v"0.3.0-")
-    deleteat! = splice!
-end
-
-
 include("matchutils.jl")
 include("matchmacro.jl")
 

--- a/src/matchmacro.jl
+++ b/src/matchmacro.jl
@@ -106,10 +106,10 @@ function unapply(val, expr::Expr, syms, guardsyms, valsyms, info, array_checked:
         ### info.tests
 
         # assign g1, g2 during the test, if needed
-        expr1 = joinexprs(info1.tests, :&&, :true)
-        expr2 = joinexprs(info2.tests, :&&, :true)
-        if length(info1.assignments) > 0;  expr1 = :($(esc(g1)) = $expr1);  end
-        if length(info2.assignments) > 0;  expr2 = :($(esc(g2)) = $expr2);  end
+        expr1 = joinexprs(unique(info1.tests), :&&, :true)
+        expr2 = joinexprs(unique(info2.tests), :&&, :true)
+        if length(info1.assignments) > 0;  expr1 = :($g1 = $expr1);  end
+        if length(info2.assignments) > 0;  expr2 = :($g2 = $expr2);  end
 
         push!(info.tests, Expr(:(||), expr1, expr2))
 
@@ -139,18 +139,18 @@ function unapply(val, expr::Expr, syms, guardsyms, valsyms, info, array_checked:
             push!(info.assignments, (expr, :($g1 ? $val1 : $val2)))
         end
 
-        for (expr, var) in info1.assignments
-            vs = getvar(x)
+        for (expr, val) in info1.assignments
+            vs = getvar(expr)
             if !(vs in sharedvars)
                 # here and below, we assign to nothing
                 # so the type info is removed
                 # TODO: move it to $val???
-                push!(info.assignments, (vs, :($g1 ? $val : nothing)))
+                push!(info.assignments, (expr, :($g1 ? $val : nothing)))
             end
         end
 
-        for (expr, var) in info2.assignments
-            vs = getvar(x)
+        for (expr, val) in info2.assignments
+            vs = getvar(expr)
             if !(vs in sharedvars)
                 push!(info.assignments, (expr, :($g2 ? $val : nothing)))
             end

--- a/src/matchmacro.jl
+++ b/src/matchmacro.jl
@@ -347,13 +347,13 @@ function gen_match_expr(v, e, code, use_let::Bool=true)
             guard = pattern.args[2].args[1]
             pattern = pattern.args[1]
             push!(info.guards, guard)
-            guardsyms = getvars(guard, true)
+            guardsyms = getvars(guard)
         else
             guardsyms = Symbol[]
         end
 
         syms = getvars(pattern)
-        valsyms = getvars(value, true)
+        valsyms = getvars(value)
 
         info = unapply(v, pattern, syms, guardsyms, valsyms, info)
 

--- a/src/matchmacro.jl
+++ b/src/matchmacro.jl
@@ -315,13 +315,15 @@ function unapply_array(val, expr::Expr, syms, guardsyms, valsyms, info, array_ch
                 end
                 seen_dots = true
                 sym = array_type_of(exprs[i].args[1])
-                s = :(Match.viewdim($val, $sdim, $i:(size($val,$sdim)-$(length(exprs)-i))))
+                j = length(exprs)-i
+                s = :(Match.slicedim($val, $dim, $i, $j))
                 unapply(s, sym, syms, guardsyms, valsyms, info, array_checked)
             elseif seen_dots
-                s = :(Match.viewdim($val, $sdim, (size($val,$sdim)-$(length(exprs)-i))))
+                j = length(exprs)-i
+                s = :(Match.slicedim($val, $dim, $j, true))
                 unapply(s, exprs[i], syms, guardsyms, valsyms, info, array_checked)
             else
-                s = :(Match.viewdim($val, $sdim, $i))
+                s = :(Match.slicedim($val, $dim, $i))
                 unapply(s, exprs[i], syms, guardsyms, valsyms, info, array_checked)
             end
         end

--- a/src/matchutils.jl
+++ b/src/matchutils.jl
@@ -60,21 +60,21 @@ end
 #
 # getvars
 #
-# get all symbols in an expression (including undefined symbols)
+# get all symbols in an expression
 
-getvars(e,all=false)         = Symbol[]
-getvars(e::Symbol,all=false) = @compat startswith(string(e),'@') ? Symbol[] : Symbol[e]
+getvars(e)         = Symbol[]
+getvars(e::Symbol) = @compat startswith(string(e),'@') ? Symbol[] : Symbol[e]
 
-function getvars(e::Expr, all=false)
+function getvars(e::Expr)
     if isexpr(e, :call)
-        getvars(e.args[2:end], all)
+        getvars(e.args[2:end])
     elseif isexpr(e, :copyast) || isexpr(e, :quote)
         Symbol[]
     else
-        getvars(e.args, all)
+        getvars(e.args)
     end
 end
-getvars(es::AbstractArray,all=false) = union([getvars(e,all) for e in es]...)
+getvars(es::AbstractArray) = union([getvars(e) for e in es]...)
 
 #
 # getvar

--- a/test/matchtests.jl
+++ b/test/matchtests.jl
@@ -149,54 +149,56 @@ end
 
 # Regular Expressions
 
+# TODO: Fix me!
+
 # Note: the following test only works because Ipv4Addr and EmailAddr
 # are (module-level) globals!
 
-const Ipv4Addr = r"(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})"
-const EmailAddr = r"\b([A-Z0-9._%+-]+)@([A-Z0-9.-]+\.[A-Z]{2,4})\b"i
+# const Ipv4Addr = r"(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})"
+# const EmailAddr = r"\b([A-Z0-9._%+-]+)@([A-Z0-9.-]+\.[A-Z]{2,4})\b"i
 
-function regex_test(str)
-    ## Defining these in the function doesn't work, because the macro
-    ## (and related functions) don't have access to the local
-    ## variables.
+# function regex_test(str)
+#     ## Defining these in the function doesn't work, because the macro
+#     ## (and related functions) don't have access to the local
+#     ## variables.
 
-    # Ipv4Addr = r"(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})"
-    # EmailAddr = r"\b([A-Z0-9._%+-]+)@([A-Z0-9.-]+\.[A-Z]{2,4})\b"i
+#     # Ipv4Addr = r"(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})"
+#     # EmailAddr = r"\b([A-Z0-9._%+-]+)@([A-Z0-9.-]+\.[A-Z]{2,4})\b"i
 
-    @match str begin
-       Ipv4Addr(_, _, octet3, _),       if int(octet3) > 30 end => "IPv4 address with octet 3 > 30"
-       Ipv4Addr()                                               => "IPv4 address"
+#     @match str begin
+#         Ipv4Addr(_, _, octet3, _),       if int(octet3) > 30 end => "IPv4 address with octet 3 > 30"
+#         Ipv4Addr()                                               => "IPv4 address"
 
-       EmailAddr(_,domain), if endswith(domain, "ucla.edu") end => "UCLA email address"
-       EmailAddr                                                => "Some email address"
+#         EmailAddr(_,domain), if endswith(domain, "ucla.edu") end => "UCLA email address"
+#         EmailAddr                                                => "Some email address"
 
-       r"MCM.*"                                                 => "In the twentieth century..."
+#         r"MCM.*"                                                 => "In the twentieth century..."
 
-       _                                                        => "No match"
-    end
-end
+#         _                                                        => "No match"
+#     end
+# end
 
-@assert regex_test("128.97.27.37")                 == "IPv4 address"
-@assert regex_test("96.17.70.24")                  == "IPv4 address with octet 3 > 30"
+# @assert regex_test("128.97.27.37")                 == "IPv4 address"
+# @assert regex_test("96.17.70.24")                  == "IPv4 address with octet 3 > 30"
 
-@assert regex_test("beej@cs.ucla.edu")             == "UCLA email address"
-@assert regex_test("beej@uchicago.edu")            == "Some email address"
+# @assert regex_test("beej@cs.ucla.edu")             == "UCLA email address"
+# @assert regex_test("beej@uchicago.edu")            == "Some email address"
 
-@assert regex_test("MCMLXXII")                     == "In the twentieth century..."
-@assert regex_test("Open the pod bay doors, HAL.") == "No match"
+# @assert regex_test("MCMLXXII")                     == "In the twentieth century..."
+# @assert regex_test("Open the pod bay doors, HAL.") == "No match"
 
 
 # Pattern extraction from arrays
 
 # extract first, rest from array 
 # (b is a subarray of the original array)
-@assert @match([1:4], [a,b...])                             == (1,[2,3,4])
-@assert @match([1:4], [a...,b])                             == ([1,2,3],4)
-@assert @match([1:4], [a,b...,c])                           == (1,[2,3],4)
+@assert @match([1:4;], [a,b...])                             == (1,[2,3,4])
+@assert @match([1:4;], [a...,b])                             == ([1,2,3],4)
+@assert @match([1:4;], [a,b...,c])                           == (1,[2,3],4)
 
 # match particular values at the beginning of a vector
-@assert @match([1:10], [1,2,a...])                          == [3:10]
-@assert @match([1:10], [1,a...,9,10])                       == [2:8]
+@assert @match([1:10;], [1,2,a...])                          == [3:10]
+@assert @match([1:10;], [1,a...,9,10])                       == [2:8]
 
 # match / collect columns
 @assert @match([1 2 3; 4 5 6], [a b...])                    == ([1,4] , [2 3; 5 6])

--- a/test/matchtests.jl
+++ b/test/matchtests.jl
@@ -197,8 +197,8 @@ end
 @assert @match([1:4;], [a,b...,c])                           == (1,[2,3],4)
 
 # match particular values at the beginning of a vector
-@assert @match([1:10;], [1,2,a...])                          == [3:10]
-@assert @match([1:10;], [1,a...,9,10])                       == [2:8]
+@assert @match([1:10;], [1,2,a...])                          == [3:10;]
+@assert @match([1:10;], [1,a...,9,10])                       == [2:8;]
 
 # match / collect columns
 @assert @match([1 2 3; 4 5 6], [a b...])                    == ([1,4] , [2 3; 5 6])
@@ -235,7 +235,7 @@ end
                  d 18 19 20])                               == ([2 3 4], [5 6 7 8; 9 10 11 12], [13 14], 17)
 
 # match 3D arrays
-m = reshape([1:8], (2,2,2))
+m = reshape([1:8;], (2,2,2))
 @assert @match(m, [a b])                                    == ([1 3; 2 4], [5 7; 6 8])
 @assert @match(m, [[1 a; b c] d])                           == (3,2,4,[5 7; 6 8])
 


### PR DESCRIPTION
`eval` should almost never be used in macros.  Here, it caused #12 and #14.

Unfortunately, it was the basis for the match macro implementation of regex captures.  They could be reimplemented, but it would be somewhat of a pain using the same syntax, so for now, they're gone.  If someone really needs it, let me know, and we might be able to find a workaround.

Also updated to work again on v0.4.