### PR TITLE
Pull request/48315a6a

### DIFF
--- a/src/matchutils.jl
+++ b/src/matchutils.jl
@@ -69,8 +69,6 @@ getvars(e::Symbol) = @compat startswith(string(e),'@') ? Symbol[] : Symbol[e]
 function getvars(e::Expr)
     if isexpr(e, :call)
         getvars(e.args[2:end])
-    elseif isexpr(e, :$) # interpolated value
-        Symbol[e.args[1]]
     else
         getvars(e.args)
     end

--- a/src/matchutils.jl
+++ b/src/matchutils.jl
@@ -69,8 +69,8 @@ getvars(e::Symbol) = @compat startswith(string(e),'@') ? Symbol[] : Symbol[e]
 function getvars(e::Expr)
     if isexpr(e, :call)
         getvars(e.args[2:end])
-    elseif isexpr(e, :copyast) || isexpr(e, :quote)
-        Symbol[]
+    elseif isexpr(e, :$) # interpolated value
+        Symbol[e.args[1]]
     else
         getvars(e.args)
     end

--- a/test/matchtests.jl
+++ b/test/matchtests.jl
@@ -316,3 +316,11 @@ end
 @assert num_match(12) == "something else"
 @assert num_match("hi") == "something else"
 @assert num_match('c') == "something else"
+
+
+# Interpolation of matches in quoted expressions
+test_interp(item) = @match item begin
+    [a, b] => :($a + $b)
+end
+@assert test_interp([1, 2]) == :(1 + 2)
+


### PR DESCRIPTION
Tentative fix for [Issue 22](https://github.com/kmsquire/Match.jl/issues/22).
What was the deleted `elseif isexpr(e, :copyast) || isexpr(e, :quote)` branch for?
The tests still pass, but this looks like it had a purpose.