### PR TITLE
Fix deprecation warnings on julia v0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+Compat 0.7.18

--- a/src/Match.jl
+++ b/src/Match.jl
@@ -1,6 +1,7 @@
 module Match
 
 using Base.Meta
+import Compat: String
 
 export @match, @ismatch
 

--- a/src/matchmacro.jl
+++ b/src/matchmacro.jl
@@ -72,7 +72,7 @@ function unapply(val, expr::Expr, syms, guardsyms, valsyms, info, array_checked:
                 push!(info.tests, :(length(names($typ)) == $(length(expr.args)-1)))
             end
 
-            dotnums = Expr[:($val.($i)) for i in 1:length(expr.args)-1]
+            dotnums = Expr[:(getfield($val, $i)) for i in 1:length(expr.args)-1]
 
             unapply(dotnums, parms, syms, guardsyms, valsyms, info, array_checked)
         end

--- a/src/matchutils.jl
+++ b/src/matchutils.jl
@@ -7,6 +7,8 @@
 
 Base.ismatch{R<:Number}(r::Range{R}, s::Number) = s in r
 Base.ismatch{T}(r::Range{T}, s::T) = s in r
+Base.ismatch(c::Char, s::Number) = false
+Base.ismatch(s::Number, c::Char) = false
 Base.ismatch(r,s) = (r == s)
 
 #


### PR DESCRIPTION
* import Compat.String to use the new String type
* comparisons between Char and Number false