### PR TITLE
Fix deprecated use of union() on arrays

### DIFF
--- a/src/matchutils.jl
+++ b/src/matchutils.jl
@@ -73,7 +73,7 @@ function getvars(e::Expr)
         getvars(e.args)
     end
 end
-getvars(es::AbstractArray) = union([getvars(e) for e in es]...)
+getvars(es::AbstractArray) = unique!(vcat([getvars(e) for e in es]...))
 
 #
 # getvar


### PR DESCRIPTION
This usage of union() is deprecated in Julia v0.7 and removed in Julia v1.0.